### PR TITLE
Use environment variable for configuration

### DIFF
--- a/1.10.2/Dockerfile
+++ b/1.10.2/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.10.2  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.10.2/configure.py
+++ b/1.10.2/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.10.2/entrypoint.sh
+++ b/1.10.2/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.10.2.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.10.2.jar
 fi

--- a/1.10.2/entrypoint.sh
+++ b/1.10.2/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.10.2.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.10.2.jar
 fi

--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.10  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.10/configure.py
+++ b/1.10/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.10/entrypoint.sh
+++ b/1.10/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.10.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.10.jar
 fi

--- a/1.10/entrypoint.sh
+++ b/1.10/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.10.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.10.jar
 fi

--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.11  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.11/configure.py
+++ b/1.11/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.11/entrypoint.sh
+++ b/1.11/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.11.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.11.jar
 fi

--- a/1.11/entrypoint.sh
+++ b/1.11/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.11.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.11.jar
 fi

--- a/1.12.1/Dockerfile
+++ b/1.12.1/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.12.1  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.12.1/configure.py
+++ b/1.12.1/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.12.1/entrypoint.sh
+++ b/1.12.1/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.1.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.12.1.jar
 fi

--- a/1.12.1/entrypoint.sh
+++ b/1.12.1/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.1.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.12.1.jar
 fi

--- a/1.12.2/Dockerfile
+++ b/1.12.2/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.12.2  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.12.2/configure.py
+++ b/1.12.2/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.12.2/entrypoint.sh
+++ b/1.12.2/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.2.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.12.2.jar
 fi

--- a/1.12.2/entrypoint.sh
+++ b/1.12.2/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.2.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.12.2.jar
 fi

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.12  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.12/configure.py
+++ b/1.12/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.12/entrypoint.sh
+++ b/1.12/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.12.jar
 fi

--- a/1.12/entrypoint.sh
+++ b/1.12/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.12.jar
 fi

--- a/1.8.3/Dockerfile
+++ b/1.8.3/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.8.3  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.8.3/configure.py
+++ b/1.8.3/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.8.3/entrypoint.sh
+++ b/1.8.3/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.3.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.8.3.jar
 fi

--- a/1.8.3/entrypoint.sh
+++ b/1.8.3/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.3.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.8.3.jar
 fi

--- a/1.8.7/Dockerfile
+++ b/1.8.7/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.8.7  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.8.7/configure.py
+++ b/1.8.7/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.8.7/entrypoint.sh
+++ b/1.8.7/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.7.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.8.7.jar
 fi

--- a/1.8.7/entrypoint.sh
+++ b/1.8.7/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.7.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.8.7.jar
 fi

--- a/1.8.8/Dockerfile
+++ b/1.8.8/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.8.8  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.8.8/configure.py
+++ b/1.8.8/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.8.8/entrypoint.sh
+++ b/1.8.8/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.8.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.8.8.jar
 fi

--- a/1.8.8/entrypoint.sh
+++ b/1.8.8/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.8.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.8.8.jar
 fi

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.8  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.8/configure.py
+++ b/1.8/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.8/entrypoint.sh
+++ b/1.8/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.8.jar
 fi

--- a/1.8/entrypoint.sh
+++ b/1.8/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.8.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.8.jar
 fi

--- a/1.9.2/Dockerfile
+++ b/1.9.2/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.9.2  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.9.2/configure.py
+++ b/1.9.2/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.9.2/entrypoint.sh
+++ b/1.9.2/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.9.2.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.9.2.jar
 fi

--- a/1.9.2/entrypoint.sh
+++ b/1.9.2/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.9.2.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.9.2.jar
 fi

--- a/1.9.4/Dockerfile
+++ b/1.9.4/Dockerfile
@@ -23,9 +23,15 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.9.4  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.9.4/configure.py
+++ b/1.9.4/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.9.4/entrypoint.sh
+++ b/1.9.4/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.9.4.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.9.4.jar
 fi

--- a/1.9.4/entrypoint.sh
+++ b/1.9.4/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.9.4.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.9.4.jar
 fi

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -23,9 +23,16 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.9  2>&1 /dev/null
 
 FROM openjdk:8-alpine
-WORKDIR /root
-RUN apk update
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 RUN apk --no-cache add bash
+WORKDIR /root
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565

--- a/1.9/configure.py
+++ b/1.9/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/1.9/entrypoint.sh
+++ b/1.9/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.9.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.9.jar
 fi

--- a/1.9/entrypoint.sh
+++ b/1.9/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.9.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.9.jar
 fi

--- a/README.md
+++ b/README.md
@@ -38,9 +38,74 @@ A Docker Bukkit/Spigot server based on Alpine.
 
 ### Running the server
 
-To start the server and accept the EULA in one fell swoop, just pass the `EULA=true` environment variable to Docker when running the container. I recommend mounting a directory from your host onto `/data` in the container to make map and server data persistent. 
+To start the server and accept the EULA in one fell swoop, just pass the `EULA=true` environment variable to Docker when running the container. I recommend mounting a directory from your host onto `/data` in the container to make map and server data persistent.
 
 `docker run -it -v /data:/data -p 25565:25565  -e EULA=true --name mc_server bbriggs/bukkit` 
+
+### Configuration
+
+You can bring your own existing data + configuration and mount it to the `/data` directory when starting the container by using the `-v` option. You may also pass configuration options as environment variables like so:
+
+`docker run -it -e DIFFICULTY=2 -e MOTD="A non-standard message" -e SPAWN_ANIMALS=false bbriggs/bukkit`
+
+This container will only attempt generate a `server.properties` file if one does not already exist. If you would like to use the configuration tool, be sure that you are not providing a configuration file or that you also set `FORCE_CONFIG=true` in the environment variables.
+
+#### Environment Files
+
+Because of the potentially large number of environment variables that you could pass in, you might want to consider using an [environment variable file](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file). 
+
+Example:
+```
+# env.list
+ALLOW_NETHER=false
+level-seed=123456789
+EULA=true
+```
+
+`docker run -d -it --env-file env.list -v $(pwd)/data:/data -p 25565:25565 bbriggs/bukkit`
+
+#### List of Environment Variables
+
+A full list of `server.properties` settings and their corresponding environment variables is included below, along with their defaults
+
+| Configuration Option          | Environment Variable          | Default                                                          |
+| ------------------------------|-------------------------------|------------------------------------------------------------------|
+| allow-flight                  | ALLOW_FLIGHT                  | `false`                                                          |
+| allow-nether                  | ALLOW_NETHER                  | `true`                                                           |
+| difficulty                    | DIFFICULTY                    | `1`                                                              |
+| enable-command-block          | ENABLE_COMMAND_BLOCK          | `false`                                                          |
+| enable-query                  | ENABLE_QUERY                  | `false`                                                          |
+| enable-rcon                   | ENABLE_RCON                   | `false`                                                          |
+| force-gamemode                | FORCE_GAMEMODE                | `false`                                                          |
+| gamemode                      | GAMEMODE                      | `0`                                                              |
+| generate-structures           | GENERATE_STRUCTURES           | `true`                                                           |
+| generator-settings            | GENERATOR_SETTINGS            |                                                                  |
+| hardcore                      | HARDCORE                      | `false`                                                          |
+| level-name                    | LEVEL_NAME                    | `world`                                                          |
+| level-seed                    | LEVEL_SEED                    |                                                                  |
+| level-type                    | LEVEL_TYPE                    | `DEFAULT`                                                        |
+| max-build-height              | MAX_BUILD_HEIGHT              |  `256`                                                           |
+| max-players                   | MAX_PLAYERS                   | `20`                                                             |
+| max-tick-time                 | MAX_TICK_TIME                 | `60000`                                                          |
+| max-world-size                | MAX_WORLD_SIZE                | `29999984`                                                       |
+| motd                          | MOTD|                         | `"A Minecraft server powered by Docker (image: bbriggs/bukkit)"` |
+| network-compression-threshold | NETWORK_COMPRESSION_THRESHOLD | `256`                                                            |
+| online-mode                   | ONLINE_MODE                   | `true`                                                           |
+| op-permission-level           | OP_PERMISSION_LEVEL           | `4`                                                              |
+| player-idle-timeout           | PLAYER_IDLE_TIMEOUT           | `0`                                                              |
+| prevent-proxy-connections     | PREVENT_PROXY_CONNECTIONS     | `false`                                                          |
+| pvp                           | PVP                           | `true`                                                           |
+| resource-pack                 | RESOURCE_PACK                 |                                                                  |
+| resource-pack-sha1            | RESOURCE_PACK_SHA1            |                                                                  |
+| server-ip                     | SERVER_IP                     |                                                                  |
+| server-port                   | SERVER_PORT                   | `25565`                                                          | 
+| snooper-enabled               | SNOOPER_ENABLED               | `true`                                                           |
+| spawn-animals                 | SPAWN_ANIMALS                 | `true`                                                           |
+| spawn-monsters                | SPAWN_MONSTERS                | `true`                                                           |
+| spawn-npcs                    | SPAWN_NPCS                    | `true`                                                           |
+| view-distance                 | VIEW_DISTANCE                 | `10`                                                             |
+| white-list                    | WHITE_LIST                    | `false`                                                          |
+
 
 ### Spigot included
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -37,6 +37,6 @@ COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565
 WORKDIR /data
 ADD entrypoint.sh /root/entrypoint.sh
-ADD properties.py /root/configure.py
+ADD configure.py /root/configure.py
 ENTRYPOINT ["/root/entrypoint.sh"]
 CMD ["craftbukkit"]

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -37,6 +37,6 @@ COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565
 WORKDIR /data
 ADD entrypoint.sh /root/entrypoint.sh
-ADD properties.py /root/properties.py
+ADD properties.py /root/configure.py
 ENTRYPOINT ["/root/entrypoint.sh"]
 CMD ["craftbukkit"]

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -23,13 +23,20 @@ RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/Build
 RUN java -jar BuildTools.jar --rev 1.12.2  2>&1 /dev/null
 
 FROM openjdk:8-alpine
+# frolvlad/alpine-python3
+RUN apk add --no-cache python3 bash && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
 WORKDIR /root
-RUN apk update
-RUN apk --no-cache add bash
 COPY --from=builder /minecraft/craftbukkit-*.jar /root
 COPY --from=builder /minecraft/spigot-*.jar /root
 EXPOSE 25565
 WORKDIR /data
 ADD entrypoint.sh /root/entrypoint.sh
+ADD properties.py /root/properties.py
 ENTRYPOINT ["/root/entrypoint.sh"]
 CMD ["craftbukkit"]

--- a/latest/configure.py
+++ b/latest/configure.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python3
+
+import os
+import datetime
+class Config:
+    def __init__(self):
+        self.properties = self._set_props()
+        return
+
+    @staticmethod
+    def _set_props():
+        props = {
+            "generator-settings": os.getenv("GENERATOR_SETTINGS"),
+            "os-permission-level": os.getenv("OP_PERMISSION_LEVEL", 4),
+            "allow-nether": os.getenv("ALLOW_NETHER", "true"),
+            "level-name": os.getenv("LEVEL_NAME", "world"),
+            "enable-query": os.getenv("ENABLE_QUERY", "false"),
+            "allow-flight": os.getenv("ALLOW_FLIGHT", "false"),
+            "prevent-proxy-connections": os.getenv("PREVENT_PROXY_CONNECTIONS", "false"),
+            "server-port": os.getenv("SERVER_PORT", 25565),
+            "max-world-size": os.getenv("MAX_WORLD_SIZE", 29999984),
+            "level-type": os.getenv("LEVEL_TYPE", "DEFAULT"),
+            "enable-rcon": os.getenv("ENABLE_RCON", "false"),
+            "level-seed": os.getenv("LEVEL_SEED"),
+            "force-gamemode": os.getenv("FORCE_GAMEMODE", "false"),
+            "server-ip": os.getenv("SERVER_IP"),
+            "network-compression-threshold": os.getenv("NETWORK_COMPRESSION_THRESHOLD", 256),
+            "spawn-npcs": os.getenv("SPAWN_NPCS", "true"),
+            "max-build-height": os.getenv("MAX_BUILD_HEIGHT", 256),
+            "white-list": os.getenv("WHITE_LIST", "false"),
+            "spawn-animals": os.getenv("SPAWN_ANIMALS", "true"),
+            "hardcore": os.getenv("HARDCORE", "false"),
+            "snooper-enabled": os.getenv("SNOOPER_ENABLED", "true"),
+            "resource-pack-sha1": os.getenv("RESOURCE_PACK_SHA1"),
+            "online-mode": os.getenv("ONLINE_MODE", "true"),
+            "resource-pack": os.getenv("RESOURCE_PACK"),
+            "pvp": os.getenv("PVP", "true"),
+            "difficulty": os.getenv("DIFFICULTY", 1),
+            "enable-command-block": os.getenv("ENABLE_COMMAND_BLOCK", "false"),
+            "gamemode": os.getenv("GAMEMODE", 0),
+            "player-idle-timeout": os.getenv("PLAYER_IDLE_TIMEOUT", 0),
+            "max-players": os.getenv("MAX_PLAYERS", 20),
+            "max-tick-time": os.getenv("MAX_TICK_TIME", 60000),
+            "spawn-monsters": os.getenv("SPAWN_MONSTERS", "true"),
+            "view-distance": os.getenv("VIEW_DISTANCE", 10),
+            "generate-structures": os.getenv("GENERATE_STRUCTURES", "true"),
+            "motd": os.getenv("MOTD", "A Minecraft server powered by Docker (image: bbriggs/bukkit)")
+        }
+        return props
+
+    def write(self, file="server.properties"):
+        with open(file, 'w') as f:
+            now = datetime.datetime.now().isoformat()
+            f.write("# Minecraft server properties\n")
+            f.write("# Automatically generated at {}\n\n".format(now))
+            for k,v in self.properties.items():
+                if not v:
+                    f.write('{}:\n'.format(k))
+                elif isinstance(v, (int)):
+                    f.write('{}: {}\n'.format(k, v))
+                else:
+                    f.write('{}: {}\n'.format(k, v))
+        return
+
+if __name__ == "__main__":
+    c = Config()
+    c.write("/data/server.properties")

--- a/latest/entrypoint.sh
+++ b/latest/entrypoint.sh
@@ -20,5 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.2.jar
 else
+    [ ! -f /data/server.properties ] && python3 /root/configure.py
     java -jar /root/$1-1.12.2.jar
 fi

--- a/latest/entrypoint.sh
+++ b/latest/entrypoint.sh
@@ -20,6 +20,6 @@ cd /data
 if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1-1.12.2.jar
 else
-    [ ! -f /data/server.properties ] && python3 /root/configure.py
+    [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
     java -jar /root/$1-1.12.2.jar
 fi


### PR DESCRIPTION
Addresses #8 

Changes: 
 - Add each `server.properties` setting as an env variable
 - Generate `server.properties` from a template using env vars and safe defaults
 - Explanation of configuration methods and mounting data in README
 - Do not configure `server.properties` if it already exists
    - Allow for overrides by passing `FORCE_CONFIG=true` as an environment variable