### PR TITLE
Container for spigot 1.14.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,14 @@
 
 FROM openjdk:8-alpine as builder
 ARG BUKKIT_VERSION=1.13.2
+LABEL stage=builder
+LABEL build=$BUILD_ID
 WORKDIR /minecraft
 RUN echo $BUKKIT_VERSION
 RUN apk update
 RUN apk --no-cache add wget git bash
 RUN wget -O /minecraft/BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+CMD git config --global --unset core.autocrlf
 RUN java -jar BuildTools.jar --rev $BUKKIT_VERSION  2>&1 /dev/null
 
 FROM openjdk:8-alpine
@@ -34,7 +37,6 @@ RUN apk add --no-cache python3 bash && \
     if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
     rm -r /root/.cache
 WORKDIR /root
-COPY --from=builder /minecraft/craftbukkit-*.jar /root/craftbukkit.jar
 COPY --from=builder /minecraft/spigot-*.jar /root/spigot.jar
 EXPOSE 25565
 WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 | `1.13`   |       |
 | `1.13.1` |       |
 | `1.13.2` |       |
-| `latest` | Builds the default ref from [GetBukkit](https://getbukkit.org/) (1.12.2 at the time of this writing) |
+| `1.14.4` |       |
+| `latest` | Build the latest Spigot jar (1.14.4 at the time of this writing) |
 
 # Docker Bukkit
 


### PR DESCRIPTION
Bukkit jar was removed from BuildTools.jar, so this will build latest spigot container.