### PR TITLE
Fix server not receiving exit signal

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,5 +21,5 @@ if [[ "$TRAVIS" = true ]]; then
     echo "stop" | java -jar /root/$1.jar
 else
     [ ! -f /data/server.properties ] || [ "${FORCE_CONFIG}" = "true" ] && python3 /root/configure.py
-    java -jar /root/$1.jar
+    exec java -jar /root/$1.jar
 fi


### PR DESCRIPTION
I noticed that the server doesn't shut down properly when the container is stopped and the wold isn't saved as a result.
This is because the entrypoint script doesn't implement a proper error handler that would stop the server.

The easy solution is to just start the java process with exec so it becomes the new main docker process and docker sends exit signals directly to the java process.

An alternative would be to install something like tini: https://github.com/krallin/tini
