### PR TITLE
Update travis-build.sh

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -3,7 +3,7 @@
 set -xe
 
 build_latest () {
-	docker build -t bbriggs/bukkit:latest
+	docker build -t bbriggs/bukkit:latest .
 }
 
 build_tag () {


### PR DESCRIPTION
add a . after latest

it still fails far later in the build for me though.

> Step 15/22 : COPY --from=builder /minecraft/craftbukkit-*.jar /root/craftbukkit.jar
> COPY failed: no source files were specified