### PR TITLE
 Add 1.16.1 and update "latest" to build it 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - TAG=1.15 DOCKERFILE=Dockerfile-1.14
   - TAG=1.15.1 DOCKERFILE=Dockerfile-1.14
   - TAG=1.15.2 DOCKERFILE=Dockerfile-1.14
+  - TAG=1.16.1 DOCKERFILE=Dockerfile-1.14
   - TAG=latest
 
 script:

--- a/Dockerfile-1.14
+++ b/Dockerfile-1.14
@@ -16,7 +16,7 @@
 #     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 FROM openjdk:8-alpine as builder
-ARG BUKKIT_VERSION=1.15.1
+ARG BUKKIT_VERSION=1.16.1
 LABEL stage=builder
 LABEL build=$BUILD_ID
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 | `1.14.4` |       |
 | `1.15`   |       |
 | `1.15.1` |       |
-| `latest` | Build the latest Spigot jar (1.15.1 at the time of this writing) |
+| `1.15.2` |       |
+| `latest` | Build the latest Spigot jar (1.15.2 at the time of this writing) |
 
 # Docker Bukkit
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 | `1.15`   |       |
 | `1.15.1` |       |
 | `1.15.2` |       |
-| `latest` | Build the latest Spigot jar (1.15.2 at the time of this writing) |
+| `1.16.1` | 1.16 is not supported by spigot as 1.16.1 was released so quickly after it. |
+| `latest` | Build the latest Spigot jar (1.16.1 at the time of this writing) |
 
 # Docker Bukkit
 


### PR DESCRIPTION
This PR also adds 1.15.2 to the README.
Spigot does not have a 1.16 release.